### PR TITLE
Added support for alternative variables (fixes #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,21 @@ Construct a polynomial from its coefficients, highest order first.
 
 ```julia
 julia> Poly([1,0,3,4])
-Poly(1x^3 + 3x^1 + 4)
+Poly(x^3 + 3 x + 4)
 ```
 
 Leading zeros are stripped.
 
 ```julia
 julia> Poly([0,1,2,3])
-Poly(1x^2 + 2x^1 + 3)
+Poly(x^2 + 2 x + 3)
+```
+
+An optional variable parameter can be added.
+
+```julia
+julia> Poly([1,2,3], 's')
+Poly(s^2 + 2 s + 3)
 ```
 
 #### poly(r::AbstractVector)
@@ -25,37 +32,43 @@ Construct a polynomial from its roots. This is in contrast to the `Poly` constru
 ```julia
 // Represents (x - 1)*(x-2)*(x-3)
 julia> poly([1,2,3])
-Poly(1x^3 + -6x^2 + 11x^1 + -6)
+Poly(x^3 - 6 x^2 + 11 x - 6)
 ```
 
 #### +, -, *, /, ==
 
-The usual arithmetic operators are overloaded to work on polynomials, and combinations of polynomials and scalars. Division by a polynomial is currently unimplemented. See [#1](https://github.com/vtjnash/Polynomial.jl/issues/1).
+The usual arithmetic operators are overloaded to work on polynomials, and combinations of polynomials and scalars. 
 
 ```julia
 julia> a = Poly([1,2])
-Poly(1x^1 + 2)
+Poly(x + 2)
 
 julia> b = Poly([1, 0, -1])
-Poly(1x^2 + -1)
+Poly(x^2 - 1)
 
 julia> 2*a
-Poly(2x^1 + 4)
+Poly(2 x + 4)
 
 julia> 2 + a
-Poly(1x^1 + 4)
+Poly(x + 4)
 
 julia> a - b
-Poly(-1x^2 + 1x^1 + 3)
+Poly(x^2 + x + 3)
 
 julia> a*b
-Poly(1x^3 + 2x^2 + -1x^1 + -2)
+Poly(x^3 + 2 x^2 - x - 2)
 
 julia> b/2
-Poly(0.5x^2 + -0.5)
+Poly(0.5 x^2 - 0.5)
+```
 
-julia> a/b
-ERROR: no method /(Poly{Int64}, Poly{Int64})
+Note that operations involving polynomials with different variables will error.
+
+```julia
+julia> a = Poly([1,2,3], 'x');
+julia> b = Poly([1,2,3], 's');
+julia> a + b
+ERROR: Polynomials must have same variable.
 ```
 
 #### polyval(p::Poly, x::Number)
@@ -71,10 +84,10 @@ Integrate the polynomial `p` term by term, optionally adding constant term `k`. 
 
 ```julia
 julia> polyint(Poly([1, 0, -1]))
-Poly(0.3333333333333333x^3 + -1.0x^1)
+Poly(0.3333 x^3 - x)
 
 julia> polyint(Poly([1, 0, -1]), 2)
-Poly(0.3333333333333333x^3 + -1.0x^1 + 2.0)
+Poly(0.3333 x^3 - x + 2)
 ```
 
 #### polyder(p::Poly)
@@ -82,7 +95,7 @@ Differentiate the polynomial `p` term by term. The order of the resulting polyno
 
 ```julia
 julia> polyder(Poly([1, 3, -1]))
-Poly(2x^1 + 3)
+Poly(2 x + 3)
 ```
 
 #### roots(p::Poly)

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Construct a polynomial from its coefficients, highest order first.
 
 ```julia
 julia> Poly([1,0,3,4])
-Poly(x^3 + 3 x + 4)
+Poly(1x^3 + 3x^1 + 4)
 ```
 
 Leading zeros are stripped.
 
 ```julia
 julia> Poly([0,1,2,3])
-Poly(x^2 + 2 x + 3)
+Poly(1x^2 + 2x^1 + 3)
 ```
 
 An optional variable parameter can be added.
@@ -32,34 +32,34 @@ Construct a polynomial from its roots. This is in contrast to the `Poly` constru
 ```julia
 // Represents (x - 1)*(x-2)*(x-3)
 julia> poly([1,2,3])
-Poly(x^3 - 6 x^2 + 11 x - 6)
+Poly(1x^3 + -6x^2 + 11x^1 + -6)
 ```
 
 #### +, -, *, /, ==
 
-The usual arithmetic operators are overloaded to work on polynomials, and combinations of polynomials and scalars. 
+The usual arithmetic operators are overloaded to work on polynomials, and combinations of polynomials and scalars.
 
 ```julia
 julia> a = Poly([1,2])
-Poly(x + 2)
+Poly(1x^1 + 2)
 
 julia> b = Poly([1, 0, -1])
-Poly(x^2 - 1)
+Poly(1x^2 + -1)
 
 julia> 2*a
-Poly(2 x + 4)
+Poly(2x^1 + 4)
 
 julia> 2 + a
-Poly(x + 4)
+Poly(1x^1 + 4)
 
 julia> a - b
-Poly(x^2 + x + 3)
+Poly(-1x^2 + 1x^1 + 3)
 
 julia> a*b
-Poly(x^3 + 2 x^2 - x - 2)
+Poly(1x^3 + 2x^2 + -1x^1 + -2)
 
 julia> b/2
-Poly(0.5 x^2 - 0.5)
+Poly(0.5x^2 + -0.5)
 ```
 
 Note that operations involving polynomials with different variables will error.
@@ -84,10 +84,10 @@ Integrate the polynomial `p` term by term, optionally adding constant term `k`. 
 
 ```julia
 julia> polyint(Poly([1, 0, -1]))
-Poly(0.3333 x^3 - x)
+Poly(0.3333333333333333x^3 + -1.0x^1)
 
 julia> polyint(Poly([1, 0, -1]), 2)
-Poly(0.3333 x^3 - x + 2)
+Poly(0.3333333333333333x^3 + -1.0x^1 + 2.0)
 ```
 
 #### polyder(p::Poly)
@@ -95,7 +95,7 @@ Differentiate the polynomial `p` term by term. The order of the resulting polyno
 
 ```julia
 julia> polyder(Poly([1, 3, -1]))
-Poly(2 x + 3)
+Poly(2x^1 + 3)
 ```
 
 #### roots(p::Poly)
@@ -117,4 +117,3 @@ julia> roots(Poly([1, 0, 0]))
  0.0
  0.0
 ```
-

--- a/src/Polynomial.jl
+++ b/src/Polynomial.jl
@@ -17,8 +17,8 @@ eps{T<:FloatingPoint}(x::Type{Complex{T}}) = Base.eps(T)
 immutable Poly{T<:Number}
     a::Vector{T}
     nzfirst::Int #for effiencicy, track the first non-zero index
-    var::String
-    function Poly(a::Vector{T}, var::String)
+    var::Symbol
+    function Poly(a::Vector{T}, var::Symbol)
         nzfirst = 0 #find and chop leading zeros
         for i = 1:length(a)
             if abs(a[i]) > 2*eps(T)
@@ -30,7 +30,9 @@ immutable Poly{T<:Number}
     end
 end
 
-Poly{T<:Number}(a::Vector{T}, var::String="x") = Poly{T}(a, var)
+Poly{T<:Number}(a::Vector{T}, var::Symbol=:x) = Poly{T}(a, var)
+Poly{T<:Number}(a::Vector{T}, var::String) = Poly{T}(a, symbol(var))
+Poly{T<:Number}(a::Vector{T}, var::Char) = Poly{T}(a, symbol(var))
 
 convert{T}(::Type{Poly{T}}, p::Poly) = Poly(convert(Vector{T}, p.a), p.var)
 promote_rule{T, S}(::Type{Poly{T}}, ::Type{Poly{S}}) = Poly{promote_type(T, S)}
@@ -281,7 +283,7 @@ function polyder{T}(p::Poly{T})
 end
 
 # create a Poly object from its roots
-function poly{T}(r::AbstractVector{T}, var="x")
+function poly{T}(r::AbstractVector{T}, var=:x)
     n = length(r)
     c = zeros(T, n+1)
     c[1] = 1
@@ -290,7 +292,9 @@ function poly{T}(r::AbstractVector{T}, var="x")
     end
     return Poly(c, var)
 end
-poly(A::Matrix, var="x") = poly(eig(A)[1], var)
+poly(A::Matrix, var=:x) = poly(eig(A)[1], var)
+poly(A::Matrix, var::String) = poly(eig(A)[1], symbol(var))
+poly(A::Matrix, var::Char) = poly(eig(A)[1], symbol(var))
 
 roots{T}(p::Poly{Rational{T}}) = roots(convert(Poly{promote_type(T, Float64)}, p))
 

--- a/src/Polynomial.jl
+++ b/src/Polynomial.jl
@@ -7,7 +7,7 @@ export Poly, polyval, polyint, polyder, poly, roots, degree
 export polydir #Deprecated
 
 import Base: length, endof, getindex, setindex!, copy, zero, one, convert
-import Base: show, *, /, //, -, +, ==, divrem, rem, eltype
+import Base: string, show, *, /, //, -, +, ==, divrem, rem, eltype
 
 eps{T}(::Type{T}) = convert(T,0)
 eps{F<:FloatingPoint}(x::Type{F}) = Base.eps(F)
@@ -15,21 +15,23 @@ eps{F<:FloatingPoint}(x::Type{F}) = Base.eps(F)
 immutable Poly{T<:Number}
     a::Vector{T}
     nzfirst::Int #for effiencicy, track the first non-zero index
-    function Poly(a::Vector{T})
+    var::Char
+    function Poly(a::Vector{T}, var::Char)
         nzfirst = 0 #find and chop leading zeros
         for i = 1:length(a)
-            if abs(a[i]) > 2*eps(T)
+            if abs(a[i]) > 2*abs(eps(T)) #abs ensures valid comparison for complex
                 break
             end
             nzfirst = i
         end
-        new(a, nzfirst)
+        new(a, nzfirst, var)
     end
 end
 
-Poly{T<:Number}(a::Vector{T}) = Poly{T}(a)
+#Poly{T<:Number}(a::Vector{T}) = Poly{T}(a, 'x')
+Poly{T<:Number}(a::Vector{T}, var::Char='x') = Poly{T}(a, var)
 
-convert{T}(::Type{Poly{T}}, p::Poly) = Poly(convert(Vector{T}, p.a))
+convert{T}(::Type{Poly{T}}, p::Poly) = Poly(convert(Vector{T}, p.a), p.var)
 promote_rule{T, S}(::Type{Poly{T}}, ::Type{Poly{S}}) = Poly{promote_type(T, S)}
 eltype{T}(::Poly{T}) = T
 
@@ -40,65 +42,118 @@ deg(p::Poly) = length(p) - 1
 getindex(p::Poly, i) = p.a[i+p.nzfirst]
 setindex!(p::Poly, v, i) = (p.a[i+p.nzfirst] = v)
 
-copy(p::Poly) = Poly(copy(p.a[1+p.nzfirst:end]))
+copy(p::Poly) = Poly(copy(p.a[1+p.nzfirst:end]), p.var)
 
-zero{T}(p::Poly{T}) = Poly([zero(T)])
+zero{T}(p::Poly{T}) = Poly([zero(T)], p.var)
 zero{T}(::Type{Poly{T}}) = Poly([zero(T)])
-one{T}(p::Poly{T}) = Poly([one(T)])
+one{T}(p::Poly{T}) = Poly([one(T)], p.var)
 one{T}(::Type{Poly{T}}) = Poly([one(T)])
+
+function _getcoefstr(value::Real)
+    #Helper func, nicely format coefficient number for poly
+    coefstr = @sprintf("%.4f", abs(value))
+    #If the coefstr ends in 4 zeros, trim them (high precision not needed)
+    if coefstr[end-3:] == "0000"
+        coefstr = coefstr[1:end-5]
+    end
+    return coefstr
+end
+
+function _getcoefstr(value::Complex)
+    #Helper func, nicely format coefficient number for poly
+    realstr = @sprintf("%.4f", abs(value.re))
+    imagstr = @sprintf("%.4f", abs(value.im))
+    sgn = sign(value.im) < 0 ? "-" : "+"
+    #If the coefstr ends in 4 zeros, trim them (high precision not needed)
+    if realstr[end-3:] == "0000"
+        realstr = realstr[1:end-5]
+    end
+    if imagstr[end-3:] == "0000"
+        imagstr = imagstr[1:end-5]
+    end
+    #Create the coefstr for the current coefficient
+    if imagstr == "0"
+        coefstr = realstr
+    else
+        coefstr = "[$realstr $sgn $(imagstr)im]"
+    end
+    return coefstr
+end
+
+function string(p::Poly)
+    #Convert polynomial into a string
+
+    #Initalize the outstring to "0"
+    outstr = "0"
+
+    #Compute the number of coefficients
+    N = length(p)
+
+    for k=1:(N)
+        #Get current coefficient in string form
+        coefstr = _getcoefstr(p[k])
+        #Power of current coefficient
+        power = N-k
+        if power == 0
+            if coefstr != "0"
+                newstr = coefstr
+            else
+                if k == 1
+                    newstr = "0"
+                else
+                    newstr = ""
+                end
+            end
+        elseif power == 1
+            if coefstr == "0"
+                newstr = ""
+            elseif coefstr == "1"
+                newstr = p.var
+            else
+                newstr = "$coefstr $(p.var)"
+            end
+        else
+            if coefstr == "0"
+                newstr = ""
+            elseif coefstr == "1"
+                newstr = "$(p.var)^$power"
+            else
+                newstr = "$coefstr $(p.var)^$power"
+            end
+        end
+
+        if k > 1
+            if newstr != ""
+                if real(p[k]) < 0
+                    outstr = "$outstr - $newstr"
+                else
+                    outstr = "$outstr + $newstr"
+                end
+            end
+        elseif k == 1 && newstr != "" && real(p[k]) < 0
+            outstr = "-$newstr"
+        else
+            outstr = newstr
+        end
+    end
+    return outstr
+end
 
 function show(io::IO, p::Poly)
     n = length(p)
-    print(io,"Poly(")
-    if n <= 0
-        print(io,"0")
-    elseif n == 1
-        print(io,p[1])
-    else
-        print(io,"$(p[1])x^$(n-1)");
-        for i = 2:n-1
-            if p[i] != 0
-                print(io," + $(p[i])x^$(n-i)")
-            end
-        end
-        if p[n] != 0
-            print(io," + $(p[n])")
-        end
-    end
-    print(io,")")
+    print(io,"Poly($(string(p)))")
 end
 
-function show{T<:Complex}(io::IO, p::Poly{T})
-    n = length(p)
-    print(io,"Poly(")
-    if n <= 0
-        print(io,"0")
-    elseif n == 1
-        print(io,"[$(p[1])]")
-    else
-        print(io,"[$(p[1])]x^$(n-1)")
-        for i = 2:n-1
-            if p[i] != 0
-                print(io," + [$(p[i])]x^$(n-i)")
-            end
-        end
-        if p[n] != 0
-            print(io," + [$(p[n])]")
-        end
-    end
-    print(io,")")
-end
-
-*(c::Number, p::Poly) = Poly(c * p.a[1+p.nzfirst:end])
-*(p::Poly, c::Number) = Poly(c * p.a[1+p.nzfirst:end])
-/(p::Poly, c::Number) = Poly(p.a[1+p.nzfirst:end] / c)
--(p::Poly) = Poly(-p.a[1+p.nzfirst:end])
+*(c::Number, p::Poly) = Poly(c * p.a[1+p.nzfirst:end], p.var)
+*(p::Poly, c::Number) = Poly(c * p.a[1+p.nzfirst:end], p.var)
+/(p::Poly, c::Number) = Poly(p.a[1+p.nzfirst:end] / c, p.var)
+-(p::Poly) = Poly(-p.a[1+p.nzfirst:end], p.var)
 
 -(p::Poly, c::Number) = +(p, -c)
 +(c::Number, p::Poly) = +(p, c)
 function +(p::Poly, c::Number)
     if length(p) < 1
-        return Poly([c,])
+        return Poly([c,], p.var)
     else
         p2 = copy(p)
         p2.a[end] += c;
@@ -107,7 +162,7 @@ function +(p::Poly, c::Number)
 end
 function -(c::Number, p::Poly)
     if length(p) < 1
-        return Poly([c,])
+        return Poly([c,], p.var)
     else
         p2 = -p;
         p2.a[end] += c;
@@ -116,6 +171,9 @@ function -(c::Number, p::Poly)
 end
 
 function +{T,S}(p1::Poly{T}, p2::Poly{S})
+    if p1.var != p2.var
+        error("Polynomials must have same variable")
+    end
     R = promote_type(T,S)
     n = length(p1)
     m = length(p2)
@@ -136,10 +194,13 @@ function +{T,S}(p1::Poly{T}, p2::Poly{S})
             a[i] = p2[i]
         end
     end
-    Poly(a)
+    Poly(a, p1.var)
 end
 
 function -{T,S}(p1::Poly{T}, p2::Poly{S})
+    if p1.var != p2.var
+        error("Polynomials must have same variable")
+    end
     R = promote_type(T,S)
     n = length(p1)
     m = length(p2)
@@ -160,15 +221,18 @@ function -{T,S}(p1::Poly{T}, p2::Poly{S})
             a[i] = -p2[i]
         end
     end
-    Poly(a)
+    Poly(a, p1.var)
 end
 
 function *{T,S}(p1::Poly{T}, p2::Poly{S})
+    if p1.var != p2.var
+        error("Polynomials must have same variable")
+    end
     R = promote_type(T,S)
     n = length(p1)
     m = length(p2)
     if n == 0 || m == 0
-        return Poly(R[])
+        return Poly(R[], p1.var)
     end
     a = zeros(R, n+m-1)
     for i = 1:length(p1)
@@ -176,10 +240,13 @@ function *{T,S}(p1::Poly{T}, p2::Poly{S})
             a[i+j-1] += p1[i] * p2[j]
         end
     end
-    Poly(a)
+    Poly(a, p1.var)
 end
 
 function divrem{T, S}(num::Poly{T}, den::Poly{S})
+    if num.var != den.var
+        error("Polynomials must have same variable")
+    end
     m = length(den)
     if m == 0
         throw(DivideError())
@@ -208,13 +275,15 @@ function divrem{T, S}(num::Poly{T}, den::Poly{S})
             r[k] -= elem
         end
     end
-    return Poly(q), Poly(r)
+    return Poly(q, num.var), Poly(r, num.var)
 end
 /(num::Poly, den::Poly) = divrem(num, den)[1]
 rem(num::Poly, den::Poly) = divrem(num, den)[2]
 
 function ==(p1::Poly, p2::Poly)
     if length(p1) != length(p2)
+        return false
+    elseif p1.var != p2.var
         return false
     else
         return p1.a[1+p1.nzfirst:end] == p2.a[1+p2.nzfirst:end]
@@ -245,7 +314,7 @@ function polyint{T}(p::Poly{T}, k::Number=0)
         a2[i] = p[i] / (n-i+1)
     end
     a2[end] = k
-    Poly(a2)
+    Poly(a2, p.var)
 end
 
 @deprecate polydir polyder
@@ -260,20 +329,20 @@ function polyder{T}(p::Poly{T})
     else
         a2 = zeros(T, 0)
     end
-    Poly(a2)
+    Poly(a2, p.var)
 end
 
 # create a Poly object from its roots
-function poly{T}(r::AbstractVector{T})
+function poly{T}(r::AbstractVector{T}, var='x')
     n = length(r)
     c = zeros(T, n+1)
     c[1] = 1
     for j = 1:n
         c[2:j+1] = c[2:j+1]-r[j]*c[1:j]
     end
-    return Poly(c)
+    return Poly(c, var)
 end
-poly(A::Matrix) = poly(eig(A)[1])
+poly(A::Matrix, var='x') = poly(eig(A)[1], var)
 
 roots{T}(p::Poly{Rational{T}}) = roots(convert(Poly{promote_type(T, Float64)}, p))
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -73,10 +73,14 @@ p4 = p2 * p3
 
 #Tests for multivariable support
 pX = Poly([1, 2, 3, 4, 5])
-pS = Poly([1, 2, 3, 4, 5], "s")
-@test pX != pS
-@test_throws pS + pX
-@test_throws pS - pX
-@test_throws pS * pX
-@test_throws pS / pX
-@test_throws pS % pX
+pS1 = Poly([1, 2, 3, 4, 5], "s")
+pS2 = Poly([1, 2, 3, 4, 5], 's')
+pS3 = Poly([1, 2, 3, 4, 5], :s)
+@test pX != pS1
+@test pS1 == pS2
+@test pS1 == pS3
+@test_throws pS1 + pX
+@test_throws pS1 - pX
+@test_throws pS1 * pX
+@test_throws pS1 / pX
+@test_throws pS1 % pX

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -73,7 +73,7 @@ p4 = p2 * p3
 
 #Tests for multivariable support
 pX = Poly([1, 2, 3, 4, 5])
-pS = Poly([1, 2, 3, 4, 5], 's')
+pS = Poly([1, 2, 3, 4, 5], "s")
 @test pX != pS
 @test_throws pS + pX
 @test_throws pS - pX

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -70,3 +70,13 @@ p4 = p2 * p3
 @test divrem(pR, pR) == (one(pR), zero(pR))
 @test_throws p1/p0
 @test_throws divrem(p0,p0)
+
+#Tests for multivariable support
+pX = Poly([1, 2, 3, 4, 5])
+pS = Poly([1, 2, 3, 4, 5], 's')
+@test pX != pS
+@test_throws pS + pX
+@test_throws pS - pX
+@test_throws pS * pX
+@test_throws pS / pX
+@test_throws pS % pX


### PR DESCRIPTION
- Added support for optional variable parameter in constructor. 
- Added string function to get string representation without 'Poly(...)' appended. 
- Improved printing function, now it: 
  - formats coefficients up to 4 decimal places (i.e. 1.123456 -> 1.1234, and 1.00005 -> 1)
  - removes unnecessary powers (i.e. x^1 is just x)
  - removes unnecessary coefficients (i.e. 1x is just x)
- All operations involving two polynomials now must have the same 'var' attribute (error is thrown otherwise)
- Added tests for new functionality, and updated the README.

I also fixed a small bug preventing complex polynomials from being created. There's no default comparison between a complex and a real (complex < real will error). Changed line 22 to fix that. Poly([1 + im, 1 - im]) now is valid.

Let me know what you think.
