### PR TITLE
Bugfix to divrem to return poly with same var

### DIFF
--- a/src/Polynomial.jl
+++ b/src/Polynomial.jl
@@ -236,7 +236,7 @@ function divrem{T, S}(num::Poly{T}, den::Poly{S})
     n = length(num)
     deg = n-m+1
     if deg <= 0
-        return zero(Poly{R}), convert(Poly{R}, num)
+        return convert(Poly{R}, zero(num)), convert(Poly{R}, num)
     end
     d = zeros(R, n)
     q = zeros(R, deg)


### PR DESCRIPTION
Previously, `divrem` could return a `Poly` with a different var
than those put in, due to `zero(Poly{R})` not knowing what var
the input `Poly` had.
